### PR TITLE
refactor: migrate LINE Notify to LINE Messaging API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ clasp push
   - https://developers.google.com/apps-script/guides/properties#add_script_properties
   - set below properties
     - `id` : calendar id
-    - `token` : Line Notify token
+    - `token` : Line Channel Access Token
+    - `groupId` : Line group id
 - setup trigger
   - https://developers.google.com/apps-script/guides/triggers/installable#managing_triggers_manually

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,9 @@
 function main() {
   const useProperties = PropertiesService.getScriptProperties();
   const id = useProperties.getProperty("id");
+  if (!id) {
+    throw new Error("Calendar ID is not set in script properties");
+  }
 
   const today = new Date();
   const tomorrow = new Date();
@@ -26,15 +29,33 @@ function main() {
   sendLineMessage(msg);
 }
 
-function sendLineMessage(msg) {
+function sendLineMessage(msg: string) {
   const useProperties = PropertiesService.getScriptProperties();
   const token = useProperties.getProperty("token");
-  const options = {
-    method: "post",
-    "content-type": "	application/x-www-form-urlencoded",
-    payload: "message=" + msg,
-    headers: { Authorization: "Bearer " + token },
+  const groupId = useProperties.getProperty("groupId");
+
+  if (!token || !groupId) {
+    throw new Error("LINE token or groupId is not set in script properties");
+  }
+
+  const payload = {
+    to: groupId,
+    messages: [
+      {
+        type: "text",
+        text: msg
+      }
+    ]
   };
 
-  UrlFetchApp.fetch("https://notify-api.line.me/api/notify", options);
+  const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
+    method: "post" as const,
+    contentType: "application/json",
+    headers: {
+      Authorization: "Bearer " + token
+    },
+    payload: JSON.stringify(payload)
+  };
+
+  UrlFetchApp.fetch("https://api.line.me/v2/bot/message/push", options);
 }


### PR DESCRIPTION
# purpose

As the title

# note

- use clasp v2.5.0 because v3.0.0-alpha doesn't work
- this update was created by roo code